### PR TITLE
BKND-42 Allows the service to receive an array of events

### DIFF
--- a/lib/callback.js
+++ b/lib/callback.js
@@ -17,29 +17,65 @@ exports.setValidator = function(val) {
 };
 
 exports.handlerSaveCallback = function (request, reply) {
-	var post = {
-		device_code : request.payload.device_code ? validatorModule.toString(request.payload.device_code) : null,
-		tmp_secret_key : request.payload.tmp_secret_key ? validatorModule.toString(request.payload.tmp_secret_key) : null,
-		app_secret_key : request.payload.app_secret_key ? validatorModule.toString(request.payload.app_secret_key) : null,
-		screen_name : request.payload.screen_name ? validatorModule.toString(request.payload.screen_name) : null,
-		event_name : request.payload.event_name ? validatorModule.toString(request.payload.event_name) : null,
-		hotel_id : request.payload.hotel_id ? validatorModule.toString(request.payload.hotel_id) : null,
-		ins_dt : new Date(),
-		ins_process_id : 'node.js'
-	};
+	var eventsToInsert = [];
+	
+	// If it is a request with only one event (&event_list not set)
+	// just grab the data from the request.
+	// When/if apps conform to the 'event_list' (below) this snippet
+	// can be removed completely.
+	if( request.payload.event_list == null ){
+		var post = {
+			device_code    : request.payload.device_code    ? validatorModule.toString(request.payload.device_code)    : null,
+			tmp_secret_key : request.payload.tmp_secret_key ? validatorModule.toString(request.payload.tmp_secret_key) : null,
+			app_secret_key : request.payload.app_secret_key ? validatorModule.toString(request.payload.app_secret_key) : null,
+			screen_name    : request.payload.screen_name    ? validatorModule.toString(request.payload.screen_name)    : null,
+			event_name     : request.payload.event_name     ? validatorModule.toString(request.payload.event_name)     : null,
+			hotel_id       : request.payload.hotel_id       ? validatorModule.toString(request.payload.hotel_id)       : null,
+			ins_dt         : new Date(),
+			ins_process_id : 'node.js'
+		};
+		eventsToInsert.push(post);
+	}
 
-	var query = mysqlConnection.query('INSERT INTO app_callback SET ?', post,
-		function(err, results) {
-			if (err) {
-				// Save the error
-				errorCollector.log(request, err);
+	// For a request with multiple events (&event_list set) we go through
+	// the list
+	else{
+		var events = JSON.parse(request.payload.event_list);
 
-				// Close the connection with successful response and send status 503 (server error)
-				var errorMsg = 'Error saving callback to database';
-			    reply(errorMsg).code(503);
+		// The device_code/secret_key does not need to be unique per event
+		// so it is grabbed from the request
+		for (var i = 0; i < events.length; i++){
+			var post = {
+				device_code    : request.payload.device_code    ? validatorModule.toString(request.payload.device_code)    : null,
+				tmp_secret_key : request.payload.tmp_secret_key ? validatorModule.toString(request.payload.tmp_secret_key) : null,
+				app_secret_key : request.payload.app_secret_key ? validatorModule.toString(request.payload.app_secret_key) : null,
+				screen_name    : events[i].screen_name          ? validatorModule.toString(events[i].screen_name)          : null,
+				event_name     : events[i].event_name           ? validatorModule.toString(events[i].event_name)           : null,
+				hotel_id       : events[i].hotel_id             ? validatorModule.toString(events[i].hotel_id)             : null,
+				timestamp      : events[i].timestamp            ? validatorModule.toString(events[i].timestamp)            : null,
+				ins_dt         : new Date(),
+				ins_process_id : 'node.js'
 			}
+			eventsToInsert.push(post);
 		}
-	);
+	}
+
+	// Go through all events (new entries) 
+	for (var i = 0; i < eventsToInsert.length; i++) {
+		var query = mysqlConnection.query('INSERT INTO app_callback SET ?', eventsToInsert[i],
+			function(err, results) {
+				// console.log(results);
+				if (err) {
+					// Save the error
+					errorCollector.log(request, err);
+
+					// Close the connection with successful response and send status 503 (server error)
+					var errorMsg = 'Error saving callback to database';
+				    reply(errorMsg).code(503);
+				}
+			}
+		);
+	};
 
 	// Close the connection with successful response
     reply({


### PR DESCRIPTION
Checks the request if there is a value for the key "event_list", if not it does as it used to. If there is a value it will parse it as JSON and attempt to grab `screen_name`, `event_name`, `hotel_id` and `timestamp`. `timestamp` /can/ be good to have since the events are inserted pretty much at the same time.

Now it will take either a request like this

```
{
 device_code
 tmp_secret_key
 app_secret_key
 screen_name
 event_name
 hotel_id
}
```

or this

```
{
 device_code
 tmp_secret_key
 app_secret_key
 event_list [
             {
              screen_name
              event_name
              hotel_id
              timestamp
             }
            ]
}
```

The code will just create an entry for each event since the database structure is unchanged.
